### PR TITLE
Adding ObjectCube requirements to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 Implementation of the ObjectCube model, defined by Grimur Tomasson
 &lt;grimurt@ru.is> and Bjorn Thor Jonsson &lt;bjorn@ru.is>
 
+# Install
+We currently don't have a ready release for this module and we have not pushed
+it to any global repository.
+
+To use this library in other Python projects, you can install the package
+directly into your project, using Pip, from Github as follows.
+
+    pip install git+git://github.com/rudatalab/python-objectcube.git@master
+    
+The last parameter is the name of the branch that you want to clone from. We
+look at master as the next release candidate, so this branch should always be
+safe to install.
+
 ##Running tests
 Currently, for running the test, you must have a running PostgreSQL instance on
 your machine. No worries, the scripts helps with initialising your own cluster

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ The last parameter is the name of the branch that you want to clone from. We
 look at master as the next release candidate, so this branch should always be
 safe to install.
 
+# Configure
+Currently, this implementation of ObjectCube depends on PostgreSQL. You
+must have a running PostgreSQL instance and create database with the
+ObjectCube schema.
+
+    mkdir ~/postgresdata; cd $_
+    initdb -d .
+	postgres -D data
+    createdb
+	psql database < curl https://raw.githubusercontent.com/rudatalab/python-objectcube/master/schema.sql
+
+Then run your application with the following environment variables set with
+your database details
+
+    export OBJECTCUBE_DB_HOST=..
+    export OBJECTCUBE_DB_USER=..
+    export OBJECTCUBE_DB_PORT=..
+    export OBJECTCUBE_DB_NAME=..
+    export OBJECTCUBE_DB_PASSWORD=..
+
+These variables have sensible defaults, so If you create your PostgreSQL
+cluster with the above mentioned commands, you don't need to set these
+variables.
+
 ##Running tests
 Currently, for running the test, you must have a running PostgreSQL instance on
 your machine. No worries, the scripts helps with initialising your own cluster

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,3 @@
-Pygments==2.0.2
-fancycompleter==0.4
-gnureadline==6.3.3
 honcho==0.5.0
-ipython==2.4.0
-nose==1.3.4
-pdbpp==0.7.2
 psycopg2==2.5.4
-pyrepl==0.8.4
-wmctrl==0.1
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ description = 'Implementation of the ObjectCube model, defined by ' \
 package_name = 'python-objectcube'
 authors = 'hlysig, siggirh'
 authors_email = 'hlysig@gmail.com'
+requirements = ''.join(open('requirements.txt').readlines()).split('\n')
 
 setup(
     name='python-objectcube',
@@ -18,5 +19,6 @@ setup(
     author=authors,
     author_email=authors_email,
     url='https://github.com/rudatalab/{0}'.format(package_name),
+    install_requires=requirements,
     packages=find_packages()
 )


### PR DESCRIPTION
We read the requirements.txt file and add it to the setup file.
If this module is now installed into a given virtual environment,
dependent packages are install as well.

Removed dependencies that are not required by ObjectCube. These are
development specific and developers can simply install them into their
own environment when needed.